### PR TITLE
Add ESP32-S3 camera streaming setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,192 @@
-# ESP32-S3 with CAM Module: Setting up MicroPython
+# ESP32-S3 Camera Streaming with MicroPython and Thonny
 
-This guide will walk you through the steps to install MicroPython on your ESP32-S3 board with a CAM module and run MicroPython scripts without needing an SD card.
+This guide walks you through preparing an ESP32-S3 board with an onboard camera to run MicroPython firmware that includes the
+camera driver, then deploying a streaming server script with Thonny. The instructions reflect the community-maintained
+firmware builds that currently provide camera support for the ESP32-S3.
 
-## Requirements
+## Prerequisites
 
-1. **ESP32-S3 board with CAM module**
-2. **USB cable**
-3. **MicroPython firmware for ESP32-S3**
-4. **esptool.py** (for flashing firmware)
-5. **Thonny IDE** (for writing and uploading scripts)
+* ESP32-S3 development board with an integrated camera module (e.g., ESP32-S3-EYE, ESP32-S3 CAM, or equivalent)
+* USB data cable
+* Python 3.9 or later on your workstation
+* `pip` and `esptool.py`
+* Thonny IDE 4.1 or later
+* A Wi-Fi network (2.4 GHz) that the board can join
 
-## Step-by-Step Guide
+## 1. Install `esptool.py`
 
-### 1. Install esptool.py
-
-You'll need `esptool.py` to flash the MicroPython firmware onto your ESP32-S3.
-
-Install `esptool.py` using pip:
-
-```sh
-pip install esptool
-```
-
-### 2. Download MicroPython Firmware
-
-Download the appropriate MicroPython firmware for the ESP32-S3 from the [MicroPython website](https://micropython.org/download/esp32/). Look for the latest `.bin` file specific to the ESP32-S3.
-
-### 3. Flash MicroPython Firmware
-
-1. **Connect the ESP32-S3 to your computer** using a USB cable.
-2. **Put the ESP32-S3 into bootloader mode**:
-   - Hold the `BOOT` button (sometimes labeled as `IO0` or `GPIO0`).
-   - Press the `RESET` button and release it.
-   - Release the `BOOT` button.
-
-3. **Find the USB port of your ESP32-S3**:
-   - On Windows: It will be a COM port like `COM3`.
-   - On Linux/macOS: It will be something like `/dev/ttyUSB0` or `/dev/ttyACM0`.
-
-4. **Use esptool.py to flash the firmware**:
+Install the flashing utility globally or in a virtual environment:
 
 ```sh
-esptool.py --chip esp32s3 --port <YOUR_PORT> --baud 460800 write_flash -z 0x1000 <path_to_your_micropython_firmware.bin>
+pip install --upgrade esptool
 ```
 
-Replace `<YOUR_PORT>` with your actual port (e.g., `COM3`, `/dev/ttyUSB0`), and `<path_to_your_micropython_firmware.bin>` with the path to the downloaded MicroPython firmware.
+> **Tip:** On Linux and macOS you may need to prepend `python3 -m` if `pip` is not mapped to Python 3.
 
-### 4. Verify the Flash
+## 2. Download a Camera-Enabled MicroPython Firmware
 
-1. Open a serial terminal program like PuTTY, Tera Term, or the serial monitor in the Arduino IDE.
-2. Connect to the same port at a baud rate of `115200`.
-3. You should see the MicroPython REPL prompt (`>>>`).
+The upstream MicroPython builds do not yet ship with ESP32-S3 camera support. Use a community firmware image that bundles the
+`esp32-camera` driver, such as the [Loboris MicroPython fork](https://github.com/loboris/MicroPython_ESP32_psRAM_LoBo) or the
+[Silabs/Unicore community builds](https://github.com/silabs-MicroPython/micropython-esp32-s3/releases). Download the latest
+`.bin` image that explicitly mentions **ESP32-S3** and **camera support**.
 
-### 5. Write and Upload MicroPython Scripts
+Save the firmware file to a known location on your workstation. The examples below assume the file is named
+`micropython-esp32s3-camera.bin`.
 
-Use Thonny IDE for an easy way to write and upload your MicroPython scripts.
+## 3. Put the ESP32-S3 into Bootloader Mode
 
-1. **Download and Install Thonny** from [thonny.org](https://thonny.org/).
-2. **Open Thonny** and go to `Tools` > `Options` > `Interpreter`.
-3. Set the interpreter to `MicroPython (ESP32)`.
-4. Set the port to your ESP32-S3’s port.
-5. Write your MicroPython script in Thonny.
-6. Click the **Run** button (green play button) to upload and execute your script on the ESP32-S3.
+1. Connect the board to your computer with the USB cable.
+2. Hold the **BOOT** (or `IO0`) button.
+3. Press and release the **RESET** button.
+4. Release the **BOOT** button.
 
-### Example Script
+## 4. Erase and Flash the Firmware
 
-Here's a simple script to test your setup:
+Identify the serial port the board exposes:
+
+* Windows: `COMx` (e.g., `COM5`)
+* Linux: `/dev/ttyUSB0` or `/dev/ttyACM0`
+* macOS: `/dev/tty.usbserial-XXXX`
+
+Erase the flash (recommended when moving between firmware families):
+
+```sh
+esptool.py --chip esp32s3 --port <PORT> erase_flash
+```
+
+Flash the camera-enabled firmware:
+
+```sh
+esptool.py --chip esp32s3 --port <PORT> --baud 460800 \
+  write_flash -z 0x0000 micropython-esp32s3-camera.bin
+```
+
+Replace `<PORT>` with the path from the previous step.
+
+## 5. Confirm the Firmware Booted
+
+Open a serial terminal (Thonny, PuTTY, `screen`, etc.) at **115200 baud**. You should see the MicroPython REPL prompt (`>>>`).
+If you receive a `ModuleNotFoundError` for `camera` in later steps, the firmware you flashed does not include the driver—repeat
+step 2 with a confirmed camera build.
+
+## 6. Prepare Thonny for the ESP32-S3
+
+1. Launch Thonny.
+2. Open **Tools ▸ Options ▸ Interpreter**.
+3. Select **MicroPython (ESP32)** as the interpreter.
+4. Choose the same serial port you used for `esptool.py`.
+5. Click **OK**, then open the REPL (bottom shell) to verify you can run simple commands like `import machine`.
+
+## 7. Upload the Camera Streaming Script
+
+1. Copy the `main.py` script from this repository (or create a new file in Thonny with the contents below).
+2. Update the Wi-Fi SSID and password constants so the board can join your network.
+3. In Thonny, choose **File ▸ Save As…**, pick **MicroPython device**, and save the script as `main.py`.
+4. Press **Ctrl+D** or reset the board; MicroPython will automatically execute `main.py` on boot.
+
+## Example: MJPEG Streaming Server (`main.py`)
 
 ```python
-import machine
+import camera
+import network
+import socket
 import time
 
-led = machine.Pin(2, machine.Pin.OUT)
+WIFI_SSID = "YOUR_WIFI_SSID"
+WIFI_PASSWORD = "YOUR_WIFI_PASSWORD"
+BOUNDARY = b"--frame"
+CONTENT_TYPE = b"multipart/x-mixed-replace; boundary=" + BOUNDARY
+CAPTURE_INTERVAL = 0.2
 
-while True:
-    led.on()
-    time.sleep(1)
-    led.off()
-    time.sleep(1)
+
+def connect_wifi(ssid: str, password: str) -> None:
+    station = network.WLAN(network.STA_IF)
+    if not station.active():
+        station.active(True)
+    if not station.isconnected():
+        station.connect(ssid, password)
+        while not station.isconnected():
+            time.sleep(0.2)
+
+
+def configure_camera() -> None:
+    camera.deinit()
+    camera.init(0, format=camera.JPEG)
+    camera.framesize(camera.FRAME_QVGA)
+    camera.quality(10)
+    camera.flip(0)
+    camera.mirror(0)
+
+
+def stream_frames(client: socket.socket) -> None:
+    client.write(b"HTTP/1.1 200 OK\r\n")
+    client.write(b"Content-Type: " + CONTENT_TYPE + b"\r\n\r\n")
+    while True:
+        frame = camera.capture()
+        if frame is None:
+            continue
+        client.write(BOUNDARY + b"\r\n")
+        client.write(b"Content-Type: image/jpeg\r\n")
+        client.write(b"Content-Length: " + str(len(frame)).encode() + b"\r\n\r\n")
+        client.write(frame)
+        client.write(b"\r\n")
+        time.sleep(CAPTURE_INTERVAL)
+
+
+def start_server(host: str = "0.0.0.0", port: int = 8080) -> None:
+    address_info = socket.getaddrinfo(host, port)[0][-1]
+    server_socket = socket.socket()
+    server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_socket.bind(address_info)
+    server_socket.listen(2)
+    try:
+        while True:
+            client, _ = server_socket.accept()
+            try:
+                stream_frames(client)
+            except OSError:
+                pass
+            finally:
+                client.close()
+    finally:
+        server_socket.close()
+
+
+def main() -> None:
+    connect_wifi(WIFI_SSID, WIFI_PASSWORD)
+    configure_camera()
+    start_server()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        camera.deinit()
 ```
 
-This script will blink the built-in LED on the ESP32-S3.
+Visit `http://<board-ip-address>:8080/` from a browser on the same network to view the MJPEG stream.
 
-## Summary
+## Deployment Considerations
 
-By following these steps, you can flash MicroPython onto your ESP32-S3 and run scripts without needing an SD card. The Thonny IDE makes it simple to write and upload scripts, providing a user-friendly environment for MicroPython development on your ESP32-S3.
-```
+* **Power:** Camera streaming draws more current than simple GPIO workloads. Use a stable 5 V supply capable of at least 1 A.
+* **Heat:** Long streaming sessions can warm the ESP32-S3. Provide airflow or attach a small heatsink if you enclose the board.
+* **Security:** The sample server is unencrypted and unauthenticated. Place the board on a trusted LAN or extend the script with
+  HTTPS termination on an upstream proxy and HTTP basic authentication or API tokens.
+* **Resilience:** For remote deployments, consider adding a watchdog timer and persisting Wi-Fi credentials in NVS to ensure the
+  device recovers gracefully after brownouts.
 
-Save this content as `README.md` in your project directory. This file will provide a clear and concise guide to setting up MicroPython on the ESP32-S3 with a CAM module.
+## Troubleshooting
+
+| Symptom | Cause | Resolution |
+| --- | --- | --- |
+| `ModuleNotFoundError: camera` | Firmware lacks camera driver | Flash a community build that bundles `esp32-camera` support. |
+| Continuous reboot cycle | Brownout due to insufficient power | Use a shorter cable and a power source rated for 1 A or more. |
+| Stream is blank or green | Sensor not initialized | Call `camera.deinit()` before `camera.init()` and double-check pin mapping if using a custom board. |
+| Browser does not show video | Network isolation or firewall | Ensure the viewing device is on the same subnet and that port 8080 is open. |
+
+## Next Steps
+
+* Add authentication and TLS (e.g., by proxying through Nginx or ESP32 SSL sockets).
+* Capture still images on demand by exposing additional HTTP endpoints.
+* Integrate with Home Assistant by wrapping the MJPEG stream in a camera entity.

--- a/main.py
+++ b/main.py
@@ -1,10 +1,83 @@
-import machine
+"""ESP32-S3 camera streaming server script for MicroPython."""
+
+import camera
+import network
+import socket
 import time
 
-led = machine.Pin(2, machine.Pin.OUT)
+WIFI_SSID = "YOUR_WIFI_SSID"
+WIFI_PASSWORD = "YOUR_WIFI_PASSWORD"
+BOUNDARY = b"--frame"
+CONTENT_TYPE = b"multipart/x-mixed-replace; boundary=" + BOUNDARY
+CAPTURE_INTERVAL = 0.2
 
-while True:
-    led.on()
-    time.sleep(1)
-    led.off()
-    time.sleep(1)
+
+def connect_wifi(ssid: str, password: str) -> None:
+    """Connect to the configured Wi-Fi network."""
+    station = network.WLAN(network.STA_IF)
+    if not station.active():
+        station.active(True)
+    if not station.isconnected():
+        station.connect(ssid, password)
+        while not station.isconnected():
+            time.sleep(0.2)
+
+
+def configure_camera() -> None:
+    """Initialise the camera sensor with JPEG output."""
+    camera.deinit()
+    camera.init(0, format=camera.JPEG)
+    camera.framesize(camera.FRAME_QVGA)
+    camera.quality(10)
+    camera.flip(0)
+    camera.mirror(0)
+
+
+def stream_frames(client: socket.socket) -> None:
+    """Send an endless MJPEG stream to the connected client."""
+    client.write(b"HTTP/1.1 200 OK\r\n")
+    client.write(b"Content-Type: " + CONTENT_TYPE + b"\r\n\r\n")
+    while True:
+        frame = camera.capture()
+        if frame is None:
+            continue
+        client.write(BOUNDARY + b"\r\n")
+        client.write(b"Content-Type: image/jpeg\r\n")
+        client.write(b"Content-Length: " + str(len(frame)).encode() + b"\r\n\r\n")
+        client.write(frame)
+        client.write(b"\r\n")
+        time.sleep(CAPTURE_INTERVAL)
+
+
+def start_server(host: str = "0.0.0.0", port: int = 8080) -> None:
+    """Start a blocking socket server that streams camera frames."""
+    address_info = socket.getaddrinfo(host, port)[0][-1]
+    server_socket = socket.socket()
+    server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_socket.bind(address_info)
+    server_socket.listen(2)
+    try:
+        while True:
+            client, _ = server_socket.accept()
+            try:
+                stream_frames(client)
+            except OSError:
+                pass
+            finally:
+                client.close()
+    finally:
+        server_socket.close()
+
+
+def main() -> None:
+    """Entry point: connect to Wi-Fi, configure the camera, and start streaming."""
+    connect_wifi(WIFI_SSID, WIFI_PASSWORD)
+    configure_camera()
+    start_server()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        camera.deinit()


### PR DESCRIPTION
## Summary
- expand the README with end-to-end instructions for flashing a community ESP32-S3 camera firmware and configuring Thonny
- add an MJPEG streaming MicroPython example that connects to Wi-Fi and serves camera frames over HTTP

## Testing
- not run (documentation and firmware guide updates only)


------
https://chatgpt.com/codex/tasks/task_e_6900e2b6bdbc833284ec5c0309780bca